### PR TITLE
feat: Use interfaces for public contracts and add regex based 3 word validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,3 +210,89 @@ func main() {
     fmt.Println(resp)
 }
 ```
+
+### Find Possible 3 Word Addresses
+
+FindPossible3wa searches the string passed in for all substrings in the form of a three word address.
+
+```go
+package main
+
+import (
+	"fmt"
+
+	w3w "github.com/what3words/w3w-go-wrapper"
+)
+
+func main() {
+	apiKey := "<YOUR_API_KEY>"
+	svc := w3w.NewService(apiKey)
+	text := `This is a valid 3 word address filled.count.soap`
+	pa := svc.FindPossible3wa(text)
+	fmt.Println(pa)
+}
+```
+
+### Is Possible 3 Word Address
+
+IsPossible3wa determines if the string passed in is in the form of a three word address.
+
+```go
+package main
+
+import (
+	"fmt"
+
+	w3w "github.com/what3words/w3w-go-wrapper"
+)
+
+func main() {
+	apiKey := "<YOUR_API_KEY>"
+	svc := w3w.NewService(apiKey)
+	pa := svc.IsPossible3wa("filled.count.fake")
+	fmt.Println(pa)
+}
+```
+
+### Did you Mean
+
+DidYouMean determines if the string passed in is almost in the form of a three word address.
+
+```go
+package main
+
+import (
+	"fmt"
+
+	w3w "github.com/what3words/w3w-go-wrapper"
+)
+
+func main() {
+	apiKey := "<YOUR_API_KEY>"
+	svc := w3w.NewService(apiKey)
+	pa := svc.DidYouMean("filled-count-fake")
+	fmt.Println(pa)
+}
+```
+
+### Is Valid 3 word address
+
+IsValid3wa validates the given string as a real three-word address by making a call to the API. The context can be used to cancel the underlying call.
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	w3w "github.com/what3words/w3w-go-wrapper"
+)
+
+func main() {
+	apiKey := "<YOUR_API_KEY>"
+	svc := w3w.NewService(apiKey)
+	pa := svc.IsValid3wa(context.Background(), "filled.count.soap")
+	fmt.Println(pa)
+}
+```

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ func main() {
     svc := w3w.NewService(apiKey)
 
     // Selected option clip to circle, multiple options can be selected, Refer https://developer.what3words.com/public-api/docs#autosuggest for options and limitations. Pass nil if options are not required
-    resp, err := svc.V3.AutoSuggest(context.Background(), "filled.count.so", &v3.AutoSuggestOpts{
+    resp, err := svc.V3().AutoSuggest(context.Background(), "filled.count.so", &v3.AutoSuggestOpts{
 		ClipToCircle: &v3.Circle{
 			Center: v3.Coordinates{
 				Lat: 51.520847,
@@ -104,22 +104,19 @@ func main() {
     apiKey := "<YOUR_API_KEY>"
     svc := w3w.NewService(apiKey)
 
-    resp, err := svc.V3.ConvertToCoordinates(context.Background(), "filled.count.soap", nil)
+    resp, err := svc.V3().ConvertToCoordinates(context.Background(), "filled.count.soap", nil)
     if err != nil {
         panic(err)
     }
     // By default response JSON is used
-    fmt.Println(resp.Json.Coordinates)
+    fmt.Println(resp.Coordinates)
 
     // Getting a geojson response
-    geoResp, err := svc.V3.ConvertToCoordinates(context.Background(), "filled.count.soap", &v3.ConvertAPIOpts{
-		Format: v3.ResponseFormatGeoJson,
-	})
+    geoResp, err := svc.V3().ConvertToCoordinatesGeoJson(context.Background(), "filled.count.soap", nil)
     if err != nil {
         panic(err)
     }
-	// If format GeoJson is not set in options, GeoJson attribute of the response will be set to nil
-	fmt.Println(geoResp.GeoJson.Features[0].Geometry.Coordinates)
+	fmt.Println(geoResp.Features[0].Geometry.Coordinates)
 }
 ```
 
@@ -140,14 +137,14 @@ import (
 func main() {
     apiKey := "<YOUR_API_KEY>"
     svc := w3w.NewService(apiKey)
-	resp, err := svc.V3.ConvertTo3wa(context.Background(), v3.Coordinates{
+	resp, err := svc.V3().ConvertTo3wa(context.Background(), v3.Coordinates{
 		Lat: 51.520847,
 		Lng: -0.195521,
 	}, nil)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(resp.Json.Words)
+	fmt.Println(resp.Words)
 
 }
 ```
@@ -169,7 +166,7 @@ import (
 func main() {
     apiKey := "<YOUR_API_KEY>"
     svc := w3w.NewService(apiKey)
-	resp, err := svc.V3.GridSection(context.Background(), v3.BoundingBox{
+	resp, err := svc.V3().GridSection(context.Background(), v3.BoundingBox{
 		SouthWest: v3.Coordinates{
 			Lat: 52.207988,
 			Lng: 0.116126,
@@ -178,11 +175,11 @@ func main() {
 			Lat: 52.208867,
 			Lng: 0.117540,
 		},
-	}, nil)
+	})
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(resp.Json.Lines)
+	fmt.Println(resp.Lines)
 
 }
 ```
@@ -206,7 +203,7 @@ import (
 func main() {
     apiKey := "<YOUR_API_KEY>"
     svc := w3w.NewService(apiKey)
-	resp, err := svc.V3.AvailableLanguages(context.Background())
+	resp, err := svc.V3().AvailableLanguages(context.Background())
 	if err != nil {
 		panic(err)
 	}

--- a/internal/version/wrapper_version.go
+++ b/internal/version/wrapper_version.go
@@ -3,5 +3,5 @@
 package version
 
 func wrapper_version() string {
-	return ""
+	return "1.0.0"
 }

--- a/internal/version/wrapper_version.go
+++ b/internal/version/wrapper_version.go
@@ -3,5 +3,5 @@
 package version
 
 func wrapper_version() string {
-	return "v1.0.0"
+	return ""
 }

--- a/pkg/apis/v3/api.go
+++ b/pkg/apis/v3/api.go
@@ -36,15 +36,15 @@ type API interface {
 	// and longitude pair to a 3 word address, in the language of your choice. It also returns country,
 	// the bounds of the grid square, a nearby place (such as a local town) and a link to our map site.
 	// Returns response in the `json` format.
-	ConvertTo3waJson(ctx context.Context, coordinates core.Coordinates, opts *ConvertAPIOpts) (*ConvertAPIJsonResponse, error)
+	ConvertTo3wa(ctx context.Context, coordinates core.Coordinates, opts *ConvertAPIOpts) (*ConvertAPIJsonResponse, error)
 	// ConvertTo3waJson wraps around /v3/convert-to-3wa which will convert a latitude
 	// and longitude pair to a 3 word address, in the language of your choice. It also returns country,
 	// the bounds of the grid square, a nearby place (such as a local town) and a link to our map site.
 	// Returns response in the `geojson` format.
 	ConvertTo3waGeoJson(ctx context.Context, coordinates core.Coordinates, opts *ConvertAPIOpts) (*ConvertAPIGeoJsonResponse, error)
-	ConvertToCoordinatesJson(ctx context.Context, words string, opts *ConvertAPIOpts) (*ConvertAPIJsonResponse, error)
+	ConvertToCoordinates(ctx context.Context, words string, opts *ConvertAPIOpts) (*ConvertAPIJsonResponse, error)
 	ConvertToCoordinatesGeoJson(ctx context.Context, words string, opts *ConvertAPIOpts) (*ConvertAPIGeoJsonResponse, error)
-	GridSectionJson(ctx context.Context, boundingBox BoundingBox) (*GridSectionJsonResponse, error)
+	GridSection(ctx context.Context, boundingBox BoundingBox) (*GridSectionJsonResponse, error)
 	GridSectionGeoJson(ctx context.Context, boundingBox BoundingBox) (*GridSectionGeoJsonResponse, error)
 	AutoSuggest(ctx context.Context, input string, opts *AutoSuggestOpts) (*AutoSuggestResponse, error)
 	AvailableLanguages(ctx context.Context) (*AvailableLanguagesResponse, error)
@@ -143,7 +143,7 @@ func (a api) convertTo3wa(ctx context.Context, coordinates core.Coordinates, opt
 	return &c2cResponse, nil
 }
 
-func (a api) ConvertTo3waJson(ctx context.Context, coordinates core.Coordinates, opts *ConvertAPIOpts) (*ConvertAPIJsonResponse, error) {
+func (a api) ConvertTo3wa(ctx context.Context, coordinates core.Coordinates, opts *ConvertAPIOpts) (*ConvertAPIJsonResponse, error) {
 	resp, err := a.convertTo3wa(ctx, coordinates, opts, "json")
 	if err != nil {
 		return nil, err
@@ -186,7 +186,7 @@ func (a api) convertToCoordinates(ctx context.Context, words string, opts *Conve
 	return &c2cResponse, nil
 }
 
-func (a api) ConvertToCoordinatesJson(ctx context.Context, words string, opts *ConvertAPIOpts) (*ConvertAPIJsonResponse, error) {
+func (a api) ConvertToCoordinates(ctx context.Context, words string, opts *ConvertAPIOpts) (*ConvertAPIJsonResponse, error) {
 	resp, err := a.convertToCoordinates(ctx, words, opts, "json")
 	if err != nil {
 		return nil, err
@@ -287,7 +287,7 @@ func (a api) gridSection(ctx context.Context, boundingBox BoundingBox, format st
 	return &gridSection, nil
 }
 
-func (a api) GridSectionJson(ctx context.Context, boundingBox BoundingBox) (*GridSectionJsonResponse, error) {
+func (a api) GridSection(ctx context.Context, boundingBox BoundingBox) (*GridSectionJsonResponse, error) {
 	resp, err := a.gridSection(ctx, boundingBox, "json")
 	if err != nil {
 		return nil, err

--- a/pkg/apis/v3/api.go
+++ b/pkg/apis/v3/api.go
@@ -11,42 +11,109 @@ import (
 	"github.com/what3words/w3w-go-wrapper/pkg/core"
 )
 
-// API models the what3words public V3 api, with each
-// endpoint having its own corresponding methods that would
-// return strictly typed structures or errors.
-// APIOptions can be used to add/modify aspects of
-// the API Controller when creating with the NewAPI function
+// API models the What3Words public v3 API. Each endpoint has a corresponding method
+// that returns strictly typed structures or errors. APIOptions can be used to
+// configure or modify the API Controller when creating an instance with the `NewAPI` function.
 //
-// By default:
+// # Default Configuration:
+// - `baseURL`: https://api.what3words.com
+// - `headers`: None
+// - `client`: http.DefaultClient
 //
-//	baseURL: https://api.what3words.com
-//	headers: None
-//	client: http.DefaultClient
 //go:generate mockery --name API --output ./mocks --outpkg mocks --case underscore
 type API interface {
-	// Setters
+	// Configuration Setters
+
+	// SetBaseURL sets the base URL for the What3Words API after initialization.
 	SetBaseURL(baseURL string)
+	// SetHeader sets a single HTTP header to include in all API requests after initialization.
 	SetHeader(headerKey, headerValue string)
+	// SetHeaderMap sets multiple HTTP headers at once for all API requests after initialization.
 	SetHeaderMap(headers map[string]string)
+	// SetClient sets a custom HTTP client for API requests after initialization.
 	SetClient(client client.HttpClient)
 
 	// Endpoints
 
-	// ConvertTo3waJson wraps around /v3/convert-to-3wa which will convert a latitude
-	// and longitude pair to a 3 word address, in the language of your choice. It also returns country,
-	// the bounds of the grid square, a nearby place (such as a local town) and a link to our map site.
-	// Returns response in the `json` format.
+	// ConvertTo3wa converts a latitude and longitude pair to a three-word address.
+	// It also provides additional information such as country, grid square bounds,
+	// a nearby place, and a link to the map site.
+	// Returns the response in JSON format.
 	ConvertTo3wa(ctx context.Context, coordinates core.Coordinates, opts *ConvertAPIOpts) (*ConvertAPIJsonResponse, error)
-	// ConvertTo3waJson wraps around /v3/convert-to-3wa which will convert a latitude
-	// and longitude pair to a 3 word address, in the language of your choice. It also returns country,
-	// the bounds of the grid square, a nearby place (such as a local town) and a link to our map site.
-	// Returns response in the `geojson` format.
+	// ConvertTo3waGeoJson performs the same conversion as `ConvertTo3wa` but
+	// returns the response in GeoJSON format.
 	ConvertTo3waGeoJson(ctx context.Context, coordinates core.Coordinates, opts *ConvertAPIOpts) (*ConvertAPIGeoJsonResponse, error)
+	// ConvertToCoordinates wraps around /v3/convert-to-coordinates which will
+	// convert a 3 word address to a latitude and longitude pair. It also returns
+	// country, the bounds of the grid square, a nearest place (such as a local town)
+	// and a link to our map site. Returns the response in the JSON format.
 	ConvertToCoordinates(ctx context.Context, words string, opts *ConvertAPIOpts) (*ConvertAPIJsonResponse, error)
+	// ConvertTo3waGeoJson performs the same conversion as `ConvertToCoordinates` but
+	// returns the response in GeoJSON format.
 	ConvertToCoordinatesGeoJson(ctx context.Context, words string, opts *ConvertAPIOpts) (*ConvertAPIGeoJsonResponse, error)
+	// GridSection wraps around the /v3/grid-section endpoint, returning a section
+	// of the 3m x 3m What3Words grid for a specified bounding box.
+	//
+	// The bounding box is defined by two coordinates:
+	// - `SouthWest` (latitude and longitude of the bottom-left corner)
+	// - `NorthEast` (latitude and longitude of the top-right corner).
+
+	// Response is returned in the JSON format.
 	GridSection(ctx context.Context, boundingBox BoundingBox) (*GridSectionJsonResponse, error)
+	// GridSectionGeoJson wraps around the /v3/grid-section endpoint, returning a section
+	// of the 3m x 3m What3Words grid for a specified bounding box in GeoJSON format.
+	//
+	// The bounding box is defined by two coordinates:
+	// - `SouthWest` (latitude and longitude of the bottom-left corner)
+	// - `NorthEast` (latitude and longitude of the top-right corner).
+	//
+	// GeoJSON format is particularly useful for rendering on maps or integrating
+	// with GIS tools, as it provides structured geospatial data.
 	GridSectionGeoJson(ctx context.Context, boundingBox BoundingBox) (*GridSectionGeoJsonResponse, error)
+	// AutoSuggest wraps around /v3/autosuggest endpoint which takes slightly
+	// incorrect 3 word address and suggest a list of valid 3 word addresses.
+	// It has powerful features that can, for example, optionally limit results
+	// to a country or area, and prioritise results that are near the user (see Clipping and Focus below).
+	//
+	// It provides corrections for the following types of input error:
+	//
+	// Typing errors
+	// - Spelling errors
+	// - Misremembered words (e.g. singular vs. plural)
+	//
+	// Input 3 word address
+	// AutoSuggest accepts either a full or partial 3 word address (it will be partial
+	// if the user is still typing in a search box, for example). A partial 3 word address
+	// must contain at least the first two words and first character of the third word.
+	// For example filled.count.s will return results, but anything shorter will not.
+	//
+	// Clipping and Focus
+	// Our clipping allows you to specify a country (or list of countries) and/or
+	// geographic area to exclude results that are not likely to be relevant to your
+	// users. To give a more targeted, shorter set of results to your users,
+	// we recommend you use the clipping parameters. If you know your user’s current
+	// location, we also strongly recommend that you use the focus to return results
+	// that are likely to be more relevant (i.e. results near the user).
+	//
+	// In summary, the clipping policy is used to optionally restrict the list of candidate
+	// AutoSuggest results, after which, if focus has been supplied, this will be used to weight
+	// the results in order of relevance to the focus.
+	//
+	// Multiple clipping policies can be specified, though only one of each type. For example you
+	// can clip to country and clip to circle in the same AutoSuggest call, and it will clip to the
+	// intersection of the two (results must be in the circle AND in the country).
+	//
+	// Language
+	// AutoSuggest will search in all languages. However, you can additionally specify a fallback language,
+	// to help the API in situations where the input is particularly messy. For normal text input,
+	// the language parameter is optional, and AutoSuggest will work well even without a language parameter.
+	// However, for voice input the language should always be specified.
 	AutoSuggest(ctx context.Context, input string, opts *AutoSuggestOpts) (*AutoSuggestResponse, error)
+	// AvailableLanguages wraps around /v3/available-languages which will
+	// retrieve a list of all available 3 word address languages,
+	// including the ISO 3166-1 alpha-2 2 letter code, English name and native name.
+	// Bosnian-Croatian-Montenegrin-Serbian is available using the language code 'oo' with
+	// Cyrillic and Latin locales ('oo_cy' and 'oo_la')
 	AvailableLanguages(ctx context.Context) (*AvailableLanguagesResponse, error)
 }
 
@@ -74,36 +141,72 @@ func (a *api) SetClient(client client.HttpClient) {
 
 type APIOption func(*api)
 
-// WithCustomHeader sets a new custom header which
-// would be sent with every request made through
-// this API
+// WithCustomHeader sets a custom HTTP header to be included with every request
+// made through this API. This is useful for scenarios like adding authentication
+// tokens or other custom headers required by the API.
+//
+// Example usage:
+//
+//	api := NewAPI("your-api-key", WithCustomHeader("X-Custom-Header", "value"))
 func WithCustomHeader(key, value string) APIOption {
 	return func(vs *api) {
 		vs.headers[key] = value
 	}
 }
 
-// WithClient sets a new custom http client can be used
-// to set the underlying http client, If a non default
-// http client is required. For example use a custom
-// transport layer or to mock the API.
+// WithClient sets a custom HTTP client to be used by the API. This is useful when
+// you need to configure a custom transport layer, use a specific client for testing,
+// or mock the API client.
+//
+// Example usage:
+//
+//	customClient := &http.Client{Timeout: 10 * time.Second}
+//	api := NewAPI("your-api-key", WithClient(customClient))
 func WithClient(client client.HttpClient) func(*api) {
 	return func(vs *api) {
 		vs.client = client
 	}
 }
 
-// WithCustomBaseURL sets a new custom base url which
-// overdide the defaut base api url. V3 would be suffixed
-// to the provided input making the whole address follow
-// this pattern <base_url>/v3/<endpoint>
+// WithCustomBaseURL sets a custom base URL for the API, overriding the default base
+// URL. The provided URL will be suffixed with `/v3`, forming the full base URL
+// for API requests, following the pattern: <base_url>/v3/<endpoint>.
+//
+// Example usage:
+//
+//	api := NewAPI("your-api-key", WithCustomBaseURL("https://custom-url.example.com"))
 func WithCustomBaseURL(baseURL string) func(*api) {
 	return func(vs *api) {
 		vs.baseURL = fmt.Sprintf("%s/v3", baseURL)
 	}
 }
 
-// NewAPI creates a new what3words API Controller.
+// NewAPI creates a new What3Words V3 API Controller instance.
+//
+// This function initializes an API controller with the provided API key and
+// applies any optional configurations specified through APIOption functions.
+//
+// The default configuration includes:
+// - `baseURL`: https://api.what3words.com/v3
+// - `headers`: Contains the API key and wrapper version header.
+// - `client`: Uses the default HTTP client (http.DefaultClient).
+//
+// You can customize the API controller by passing options such as custom headers,
+// HTTP clients, or base URLs.
+//
+// Example usage:
+//
+//	api := NewAPI("your-api-key",
+//	    WithCustomHeader("X-Custom-Header", "value"),
+//	    WithClient(customClient),
+//	)
+//
+// # Parameters:
+// - `apiKey`: The API key for authenticating requests to the What3Words API.
+// - `opts`: Optional configuration functions to modify the API controller.
+//
+// # Returns:
+// A new API controller instance with the specified configuration.
 func NewAPI(apiKey string, opts ...APIOption) API {
 	headers := make(map[string]string)
 	headers[core.HEADER_API_KEY] = apiKey
@@ -159,10 +262,6 @@ func (a api) ConvertTo3waGeoJson(ctx context.Context, coordinates core.Coordinat
 	return resp.ConvertAPIGeoJsonResponse, nil
 }
 
-// ConvertToCoordinates wraps around /v3/convert-to-coordinates which will
-// convert a 3 word address to a latitude and longitude pair. It also returns
-// country, the bounds of the grid square, a nearest place (such as a local town)
-// and a link to our map site.
 func (a api) convertToCoordinates(ctx context.Context, words string, opts *ConvertAPIOpts, format string) (*convertAPIResponse, error) {
 	var c2cResponse convertAPIResponse
 	queryParams := make(map[string]string)
@@ -202,44 +301,6 @@ func (a api) ConvertToCoordinatesGeoJson(ctx context.Context, words string, opts
 	return resp.ConvertAPIGeoJsonResponse, nil
 }
 
-// AutoSuggest wraps around /v3/autosuggest endpoint which takes slightly
-// incorrect 3 word address and suggest a list of valid 3 word addresses.
-// It has powerful features that can, for example, optionally limit results
-// to a country or area, and prioritise results that are near the user (see Clipping and Focus below).
-//
-// It provides corrections for the following types of input error:
-//
-// Typing errors
-// - Spelling errors
-// - Misremembered words (e.g. singular vs. plural)
-//
-// Input 3 word address
-// AutoSuggest accepts either a full or partial 3 word address (it will be partial
-// if the user is still typing in a search box, for example). A partial 3 word address
-// must contain at least the first two words and first character of the third word.
-// For example filled.count.s will return results, but anything shorter will not.
-//
-// Clipping and Focus
-// Our clipping allows you to specify a country (or list of countries) and/or
-// geographic area to exclude results that are not likely to be relevant to your
-// users. To give a more targeted, shorter set of results to your users,
-// we recommend you use the clipping parameters. If you know your user’s current
-// location, we also strongly recommend that you use the focus to return results
-// that are likely to be more relevant (i.e. results near the user).
-//
-// In summary, the clipping policy is used to optionally restrict the list of candidate
-// AutoSuggest results, after which, if focus has been supplied, this will be used to weight
-// the results in order of relevance to the focus.
-//
-// Multiple clipping policies can be specified, though only one of each type. For example you
-// can clip to country and clip to circle in the same AutoSuggest call, and it will clip to the
-// intersection of the two (results must be in the circle AND in the country).
-//
-// Language
-// AutoSuggest will search in all languages. However, you can additionally specify a fallback language,
-// to help the API in situations where the input is particularly messy. For normal text input,
-// the language parameter is optional, and AutoSuggest will work well even without a language parameter.
-// However, for voice input the language should always be specified.
 func (a api) AutoSuggest(ctx context.Context, input string, opts *AutoSuggestOpts) (*AutoSuggestResponse, error) {
 	var autoSuggest autoSuggestResponse
 	queryParams := make(map[string]string)
@@ -263,10 +324,6 @@ func (a api) AutoSuggest(ctx context.Context, input string, opts *AutoSuggestOpt
 	return &autoSuggest.AutoSuggestResponse, nil
 }
 
-// GridSection wraps around /v3/grid-section which will return a section
-// section of the 3m x 3m what3words grid for a bounding box. The bounding box
-// is specified by lat,lng,lat,lng as south,west,north,east. You can request the
-// grid in GeoJSON format, making it very simple to display on a map.
 func (a api) gridSection(ctx context.Context, boundingBox BoundingBox, format string) (*gridSectionResponse, error) {
 	var gridSection gridSectionResponse
 	queryParams := make(map[string]string)
@@ -303,11 +360,6 @@ func (a api) GridSectionGeoJson(ctx context.Context, boundingBox BoundingBox) (*
 	return resp.GridSectionGeoJsonResponse, nil
 }
 
-// AvailableLanguages wraps around /v3/available-languages which will
-// retrieve a list of all available 3 word address languages,
-// including the ISO 3166-1 alpha-2 2 letter code, English name and native name.
-// Bosnian-Croatian-Montenegrin-Serbian is available using the language code 'oo' with
-// Cyrillic and Latin locales ('oo_cy' and 'oo_la')
 func (a api) AvailableLanguages(ctx context.Context) (*AvailableLanguagesResponse, error) {
 	var availableLanguages availableLanguagesResponse
 	err := core.MakeGetRequest(ctx, a.client, a.baseURL, map[string]string{}, a.headers, &availableLanguages, "available-languages")

--- a/pkg/apis/v3/api_test.go
+++ b/pkg/apis/v3/api_test.go
@@ -52,7 +52,7 @@ var c23waGeoJson = `{"features":[{"bbox":[-1.246252,51.751159,-1.246208,51.75118
 // 	}
 // }
 
-func setupAPI(t *testing.T) *v3.API {
+func setupAPI(t *testing.T) v3.API {
 	apiKey := os.Getenv("X_API_KEY")
 	if apiKey == "" {
 		t.Fatal("ERROR: X_API_KEY is empty or not found")
@@ -63,100 +63,69 @@ func setupAPI(t *testing.T) *v3.API {
 }
 
 func TestConvertToCoordinatesJSON(t *testing.T) {
-	resp, err := setupAPI(t).ConvertToCoordinates(context.Background(), "filled.count.soap", nil)
+	resp, err := setupAPI(t).ConvertToCoordinatesJson(context.Background(), "filled.count.soap", nil)
 	if err != nil {
 		t.Fatalf("ERROR: Failed to get cordinates from API due to err : %v", err)
 	}
-	if resp.GeoJson != nil {
-		t.Fatal("ERROR: GeoJson output should be set to nil since format by default is json")
-	}
-	if resp.Json == nil {
-		t.Fatal("ERROR: Json should have value since format by default is json")
-	}
-
 	var expected v3.ConvertAPIJsonResponse
 	json.Unmarshal([]byte(c2cJson), &expected)
-	if !reflect.DeepEqual(expected, *resp.Json) {
-		t.Fatalf("ERROR: Expected output '%v' recieved '%v'", expected, *resp.Json)
+	if !reflect.DeepEqual(expected, *resp) {
+		t.Fatalf("ERROR: Expected output '%v' recieved '%v'", expected, *resp)
 	}
 }
 
 func TestConvertToCoordinatesGeoJSON(t *testing.T) {
-	resp, err := setupAPI(t).ConvertToCoordinates(context.Background(), "filled.count.soap", &v3.ConvertAPIOpts{
-		Format: v3.ResponseFormatGeoJson,
-	})
+	resp, err := setupAPI(t).ConvertToCoordinatesGeoJson(context.Background(), "filled.count.soap", nil)
 	if err != nil {
 		t.Fatalf("ERROR: Failed to get cordinates from API due to err : %v", err)
 	}
-	if resp.GeoJson == nil {
-		t.Fatal("ERROR: GeoJson output should be set since format has been overidden to use geojson")
-	}
-	if resp.Json != nil {
-		t.Fatal("ERROR: Json output should be nil since format has been overidden to use geojson")
-	}
-
 	var expected v3.ConvertAPIGeoJsonResponse
 	json.Unmarshal([]byte(c2cGeoJson), &expected)
-	if !reflect.DeepEqual(expected, *resp.GeoJson) {
-		t.Fatalf("ERROR: Expected output '%v' recieved '%v'", expected, *resp.GeoJson)
+	if !reflect.DeepEqual(expected, *resp) {
+		t.Fatalf("ERROR: Expected output '%v' recieved '%v'", expected, *resp)
 	}
 }
 
 func TestConvertToCoordinatesInvalidWords(t *testing.T) {
-	_, err := setupAPI(t).ConvertToCoordinates(context.Background(), "fill.fake.fill", nil)
+	_, err := setupAPI(t).ConvertToCoordinatesJson(context.Background(), "fill.fake.fill", nil)
 	if err == nil {
 		t.Fatal("ERROR: error should be set to BadWords")
 	}
 }
 
 func TestConvertTo3WAJSON(t *testing.T) {
-	resp, err := setupAPI(t).ConvertTo3wa(context.Background(), core.Coordinates{
+	resp, err := setupAPI(t).ConvertTo3waJson(context.Background(), core.Coordinates{
 		Lng: -1.24623,
 		Lat: 51.751172,
 	}, nil)
 	if err != nil {
 		t.Fatalf("ERROR: Failed to get cordinates from API due to err : %v", err)
 	}
-	if resp.GeoJson != nil {
-		t.Fatal("ERROR: GeoJson output should be set to nil since format by default is json")
-	}
-	if resp.Json == nil {
-		t.Fatal("ERROR: Json should have value since format by default is json")
-	}
 
 	var expected v3.ConvertAPIJsonResponse
 	json.Unmarshal([]byte(c23waJson), &expected)
-	if !reflect.DeepEqual(expected, *resp.Json) {
-		t.Fatalf("ERROR: Expected output '%v' recieved '%v'", expected.Words, resp.Json.Words)
+	if !reflect.DeepEqual(expected, *resp) {
+		t.Fatalf("ERROR: Expected output '%v' recieved '%v'", expected.Words, resp.Words)
 	}
 }
 
 func TestConvertTo3WAGeoJSON(t *testing.T) {
-	resp, err := setupAPI(t).ConvertTo3wa(context.Background(), core.Coordinates{
+	resp, err := setupAPI(t).ConvertTo3waGeoJson(context.Background(), core.Coordinates{
 		Lng: -1.24623,
 		Lat: 51.751172,
-	}, &v3.ConvertAPIOpts{
-		Format: v3.ResponseFormatGeoJson,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("ERROR: Failed to get cordinates from API due to err : %v", err)
 	}
-	if resp.GeoJson == nil {
-		t.Fatal("ERROR: GeoJson output should be set since format has been overidden to use geojson")
-	}
-	if resp.Json != nil {
-		t.Fatal("ERROR: Json output should be nil since format has been overidden to use geojson")
-	}
-
 	var expected v3.ConvertAPIGeoJsonResponse
 	json.Unmarshal([]byte(c23waGeoJson), &expected)
-	if !reflect.DeepEqual(expected, *resp.GeoJson) {
-		t.Fatalf("ERROR: Expected output '%v' recieved '%v'", expected, *resp.GeoJson)
+	if !reflect.DeepEqual(expected, *resp) {
+		t.Fatalf("ERROR: Expected output '%v' recieved '%v'", expected, *resp)
 	}
 }
 
 func TestConvertTo3WAInvalidWords(t *testing.T) {
-	_, err := setupAPI(t).ConvertToCoordinates(context.Background(), "fill.fake.fill", nil)
+	_, err := setupAPI(t).ConvertToCoordinatesJson(context.Background(), "fill.fake.fill", nil)
 	if err == nil {
 		t.Fatal("ERROR: error should be set to BadWords")
 	}
@@ -168,7 +137,7 @@ func TestConvertTo3WAInvalidWords(t *testing.T) {
 
 func TestGridSectionJSON(t *testing.T) {
 
-	resp, err := setupAPI(t).GridSection(context.Background(), v3.BoundingBox{
+	_, err := setupAPI(t).GridSectionJson(context.Background(), v3.BoundingBox{
 		SouthWest: core.Coordinates{
 			Lat: 52.207988,
 			Lng: 0.116126,
@@ -177,33 +146,6 @@ func TestGridSectionJSON(t *testing.T) {
 			Lat: 52.208867,
 			Lng: 0.117540,
 		},
-	}, nil)
-	if err != nil {
-		t.Fatalf("ERROR: Failed to get grid section from API - %v", err)
-	}
-	if err != nil {
-		t.Fatalf("ERROR: Failed to get cordinates from API due to err : %v", err)
-	}
-	if resp.GeoJson != nil {
-		t.Fatal("ERROR: GeoJson output should be set to nil since format by default is json")
-	}
-	if resp.Json == nil {
-		t.Fatal("ERROR: Json should have value since format by default is json")
-	}
-}
-
-func TestGridSectionGeoJSON(t *testing.T) {
-	resp, err := setupAPI(t).GridSection(context.Background(), v3.BoundingBox{
-		SouthWest: core.Coordinates{
-			Lat: 52.207988,
-			Lng: 0.116126,
-		},
-		NorthEast: core.Coordinates{
-			Lat: 52.208867,
-			Lng: 0.117540,
-		},
-	}, &v3.GridSectionOpts{
-		Format: v3.ResponseFormatGeoJson,
 	})
 	if err != nil {
 		t.Fatalf("ERROR: Failed to get grid section from API - %v", err)
@@ -211,11 +153,24 @@ func TestGridSectionGeoJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ERROR: Failed to get cordinates from API due to err : %v", err)
 	}
-	if resp.GeoJson == nil {
-		t.Fatal("ERROR: GeoJson output should be set since format has been overidden to use geojson")
+}
+
+func TestGridSectionGeoJSON(t *testing.T) {
+	_, err := setupAPI(t).GridSectionGeoJson(context.Background(), v3.BoundingBox{
+		SouthWest: core.Coordinates{
+			Lat: 52.207988,
+			Lng: 0.116126,
+		},
+		NorthEast: core.Coordinates{
+			Lat: 52.208867,
+			Lng: 0.117540,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ERROR: Failed to get grid section from API - %v", err)
 	}
-	if resp.Json != nil {
-		t.Fatal("ERROR: Json output should be nil since format has been overidden to use geojson")
+	if err != nil {
+		t.Fatalf("ERROR: Failed to get cordinates from API due to err : %v", err)
 	}
 }
 
@@ -423,7 +378,7 @@ func TestThreadSafety(t *testing.T) {
 	for i := 0; i < count; i++ {
 		go func() {
 			defer wg.Done()
-			_, err := svc.ConvertToCoordinates(context.Background(), "filled.count.soap", nil)
+			_, err := svc.ConvertToCoordinatesJson(context.Background(), "filled.count.soap", nil)
 			if err != nil {
 				t.Errorf("ERROR: Failed to get coordinates from API - %v", err)
 			}

--- a/pkg/apis/v3/api_test.go
+++ b/pkg/apis/v3/api_test.go
@@ -63,7 +63,7 @@ func setupAPI(t *testing.T) v3.API {
 }
 
 func TestConvertToCoordinatesJSON(t *testing.T) {
-	resp, err := setupAPI(t).ConvertToCoordinatesJson(context.Background(), "filled.count.soap", nil)
+	resp, err := setupAPI(t).ConvertToCoordinates(context.Background(), "filled.count.soap", nil)
 	if err != nil {
 		t.Fatalf("ERROR: Failed to get cordinates from API due to err : %v", err)
 	}
@@ -87,14 +87,14 @@ func TestConvertToCoordinatesGeoJSON(t *testing.T) {
 }
 
 func TestConvertToCoordinatesInvalidWords(t *testing.T) {
-	_, err := setupAPI(t).ConvertToCoordinatesJson(context.Background(), "fill.fake.fill", nil)
+	_, err := setupAPI(t).ConvertToCoordinates(context.Background(), "fill.fake.fill", nil)
 	if err == nil {
 		t.Fatal("ERROR: error should be set to BadWords")
 	}
 }
 
 func TestConvertTo3WAJSON(t *testing.T) {
-	resp, err := setupAPI(t).ConvertTo3waJson(context.Background(), core.Coordinates{
+	resp, err := setupAPI(t).ConvertTo3wa(context.Background(), core.Coordinates{
 		Lng: -1.24623,
 		Lat: 51.751172,
 	}, nil)
@@ -125,7 +125,7 @@ func TestConvertTo3WAGeoJSON(t *testing.T) {
 }
 
 func TestConvertTo3WAInvalidWords(t *testing.T) {
-	_, err := setupAPI(t).ConvertToCoordinatesJson(context.Background(), "fill.fake.fill", nil)
+	_, err := setupAPI(t).ConvertToCoordinates(context.Background(), "fill.fake.fill", nil)
 	if err == nil {
 		t.Fatal("ERROR: error should be set to BadWords")
 	}
@@ -137,7 +137,7 @@ func TestConvertTo3WAInvalidWords(t *testing.T) {
 
 func TestGridSectionJSON(t *testing.T) {
 
-	_, err := setupAPI(t).GridSectionJson(context.Background(), v3.BoundingBox{
+	_, err := setupAPI(t).GridSection(context.Background(), v3.BoundingBox{
 		SouthWest: core.Coordinates{
 			Lat: 52.207988,
 			Lng: 0.116126,
@@ -378,7 +378,7 @@ func TestThreadSafety(t *testing.T) {
 	for i := 0; i < count; i++ {
 		go func() {
 			defer wg.Done()
-			_, err := svc.ConvertToCoordinatesJson(context.Background(), "filled.count.soap", nil)
+			_, err := svc.ConvertToCoordinates(context.Background(), "filled.count.soap", nil)
 			if err != nil {
 				t.Errorf("ERROR: Failed to get coordinates from API - %v", err)
 			}

--- a/pkg/apis/v3/types.go
+++ b/pkg/apis/v3/types.go
@@ -79,12 +79,8 @@ func (ctr convertAPIResponse) GetError() error {
 	return ctr.Error
 }
 
-// ConvertAPIResponse encapsulates 2 pointers to
-// Json and GeoJson response structs, based on the
-// Format provided, one will be set while other
-// set to nil
-
 // AutoSuggest API
+
 type Circle struct {
 	Center   Coordinates
 	RadiusKm float64
@@ -142,10 +138,15 @@ type AutoSuggestOpts struct {
 	Language string
 	// Makes AutoSuggest prefer results on land to those in the sea. This setting is on by default.
 	// Use false to disable this setting and receive more suggestions in the sea.
+	// Set easily using `core.Bool(false)`
 	PreferLand *bool
 	// Locale to specify a variant of a language
-	Locale       string
-	NResults     *int
+	Locale string
+	// The number of AutoSuggest results to return (max 100).
+	// Set easily using `core.Int(10)`
+	NResults *int
+	// Number of results within the results set which will have a focus
+	// Set easily using `core.Int(10)`
 	NFocusResult *int
 }
 

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -9,6 +9,6 @@ type Coordinates struct {
 	Lng float64 `json:"lng"`
 }
 
-func (c Coordinates) String() string {
+func (c Coordinates) AsQueryParam() string {
 	return fmt.Sprintf("%.6f,%.6f", c.Lat, c.Lng)
 }

--- a/pkg/core/utils.go
+++ b/pkg/core/utils.go
@@ -60,3 +60,11 @@ func MakeGetRequest(
 	}
 	return nil
 }
+
+func Bool(v bool) *bool {
+	return &v
+}
+
+func Int(v int) *int {
+	return &v
+}

--- a/w3w.go
+++ b/w3w.go
@@ -15,25 +15,38 @@ var (
 	regexDidYouMean    = regexp.MustCompile(`^/?[^0-9\x60~!@#$%^&*()+\-_=\[\{\]}\\|'<>.,?/;:£§º©®\s]{1,}[.\x{FF61}\x{3002}\x{FF65}\x{30FB}\x{FE12}\x{17D4}\x{0964}\x{1362}\x{3002}:။^_۔։ ,\\/+'&\\:;|\x{3000}-]{1,2}[^0-9\x60~!@#$%^&*()+\-_=\[\{\]}\\|'<>.,?/;:£§º©®\s]{1,}[.\x{FF61}\x{3002}\x{FF65}\x{30FB}\x{FE12}\x{17D4}\x{0964}\x{1362}\x{3002}:။^_۔։ ,\\/+'&\\:;|\x{3000}-]{1,2}[^0-9\x60~!@#$%^&*()+\-_=\[\{\]}\\|'<>.,?/;:£§º©®\s]{1,}$`)
 )
 
-// Service wraps the what3words public Service with each
-// version of the API available under its own
-// method. A call for example to the v3/available-languages
-// api would be made as such
+// Service wraps the What3Words public API, providing methods for each
+// version of the API available under its own method. For example, a call
+// to the v3/available-languages API would be made as follows:
 //
-// svc := NewService(apiKey)
+//	svc := NewService(apiKey)
 //
-// languages, err := svc.V3().AvailableLanguages(context.Background())
+//	languages, err := svc.V3().AvailableLanguages(context.Background())
 //
 //	if err != nil {
 //		return err
 //	}
+//
 //go:generate mockery --name Service --output ./mocks --outpkg mocks --case underscore
 type Service interface {
+
+	// V3 provides access to methods/endpoints under the v3 version of the What3Words API.
+	// Example usage:
+	//   svc := NewService(apiKey)
+	//   result, err := svc.V3().AvailableLanguages(ctx)
+	//   if err != nil {
+	//       // handle error
+	//   }
 	V3() v3.API
+	// FindPossible3wa searches the string passed in for all substrings in the form of a three word address.
 	FindPossible3wa(input string) []string
+	// IsPossible3wa determines if the string passed in is in the form of a three word address.
 	IsPossible3wa(input string) bool
-	IsValid3wa(ctx context.Context, input string) bool
+	// DidYouMean determines if the string passed in is almost in the form of a three word address.
 	DidYouMean(input string) bool
+	// IsValid3wa validates the given string as a real three-word address by
+	// making a call to the API. The context can be used to cancel the underlying call.
+	IsValid3wa(ctx context.Context, input string) bool
 }
 
 type service struct {
@@ -42,20 +55,20 @@ type service struct {
 
 type ServiceOpts func(*service)
 
-// WithCustomBaseURL allows you to set a custom base url
-// for the what3words service. This is useful for testing or when calling an
-// self-hosted enterprise server
+// WithCustomBaseURL allows you to set a custom base URL for the What3Words service.
+// This is useful for testing purposes or when interacting with a self-hosted
+// enterprise server.
 //
-// # This sets the base url for all versions of the API in the Service
+// # Note:
+// This custom base URL is applied to all API versions within the Service.
 //
-// For example:
+// Example usage:
 //
-// Service := NewService(ServiceKey, WithCustomBaseURL("XXXXXXXXXXXXXXXXXXXXXXXXXX"))
+//	service := NewService(apiKey, WithCustomBaseURL("https://custom-base-url.example.com"))
 //
-// languages, err := Service.V3.AvailableLanguages(context.Background())
-//
+//	languages, err := service.V3().AvailableLanguages(context.Background())
 //	if err != nil {
-//		return err
+//	    return err
 //	}
 func WithCustomBaseURL(baseURL string) ServiceOpts {
 	return func(svc *service) {
@@ -63,20 +76,19 @@ func WithCustomBaseURL(baseURL string) ServiceOpts {
 	}
 }
 
-// WithCustomHeader allows you to set a custom header
-// for the what3words Service. All requests sent from
-// this client would contain this header
+// WithCustomHeader allows you to set a custom header for the What3Words service.
+// All requests sent from this client will include this header.
 //
-// # This sets the header for all versions in the Service
+// # Note:
+// The custom header is applied to all API versions within the Service.
 //
-// For example:
+// Example usage:
 //
-// Service := NewService(ServiceKey, WithCustomHeader("X-Custom-Header", "XXXXXXXXXXXXXXXXXXXXXXXXXX"))
+//	service := NewService(apiKey, WithCustomHeader("X-Custom-Header", "header-value"))
 //
-// languages, err := Service.V3.AvailableLanguages(context.Background())
-//
+//	languages, err := service.V3().AvailableLanguages(context.Background())
 //	if err != nil {
-//		return err
+//	    return err
 //	}
 func WithCustomHeader(key, value string) ServiceOpts {
 	return func(svc *service) {
@@ -84,38 +96,61 @@ func WithCustomHeader(key, value string) ServiceOpts {
 	}
 }
 
-// WithClient allows you to set a custom http client
-// for the what3words Service. This is useful for testing or
-// setting a client with non-default net/http settings.
+// WithClient allows you to set a custom HTTP client for the What3Words service.
+// This is useful for testing purposes or when you need to configure a client
+// with non-default settings for the net/http package.
 //
-// Client is anything that implements w3w-go-wrapper/internal/client/HttpClient
-// interface
+// The client must implement the w3w-go-wrapper/internal/client/HttpClient interface.
 //
-// # This sets the http client for all versions in the Service
+// # Note:
+// The custom HTTP client is applied to all API versions within the Service.
 //
-// For example:
+// Example usage:
 //
-// Service := NewService(ServiceKey, WithClient(&http.Client{})
+//	service := NewService(apiKey, WithClient(&http.Client{}))
 func WithClient(client client.HttpClient) ServiceOpts {
 	return func(svc *service) {
 		svc.v3api.SetClient(client)
 	}
 }
 
-// WithV3API allows you to set a custom what3words v3
-// service. Construct a v3 service with the w3w-go-wrapper/pkg/v3 NewService
-// function and set it.
-// Usefull if you want to set Custom anything specific to a version
+// WithV3API allows you to set a custom What3Words v3 service.
+// You can construct a v3 service using the w3w-go-wrapper/pkg/v3 `NewService` function
+// and configure it as needed before setting it.
+//
+// This is useful if you need to customize settings specific to the v3 API.
 func WithV3API(v3 v3.API) ServiceOpts {
 	return func(svc *service) {
 		svc.v3api = v3
 	}
 }
 
-// NewService creates a new what3words Service wrapper
-func NewService(ServiceKey string, opts ...ServiceOpts) Service {
+// NewService creates a new What3Words service wrapper.
+// This function initializes the service with the provided API key and applies
+// any optional configurations specified through ServiceOpts.
+//
+// # Parameters:
+//   - `apiKey`: The API key used for authenticating requests to the What3Words API.
+//   - `opts`: Optional configurations for customizing the service, such as setting
+//     a custom base URL, HTTP client, or v3 API service.
+//
+// Example usage:
+//
+//	service := NewService("your-api-key",
+//		WithCustomBaseURL("https://custom-url.example.com"),
+//		WithClient(&http.Client{}),
+//	)
+//
+//	languages, err := service.V3().AvailableLanguages(context.Background())
+//	if err != nil {
+//	    // handle error
+//	}
+//
+// # Returns:
+// A Service interface that provides access to What3Words API methods.
+func NewService(apiKey string, opts ...ServiceOpts) Service {
 	svc := service{
-		v3api: v3.NewAPI(ServiceKey),
+		v3api: v3.NewAPI(apiKey),
 	}
 	for _, opt := range opts {
 		opt(&svc)

--- a/w3w.go
+++ b/w3w.go
@@ -174,7 +174,7 @@ func (svc service) IsValid3wa(ctx context.Context, input string) bool {
 	if svc.IsPossible3wa(input) {
 		if resp, err := svc.V3().AutoSuggest(ctx, input, &v3.AutoSuggestOpts{
 			NResults: core.Int(1),
-		}); err != nil {
+		}); err == nil {
 			if len(resp.Suggestions) >= 1 {
 				return resp.Suggestions[0].Words == input
 			}

--- a/w3w_test.go
+++ b/w3w_test.go
@@ -87,7 +87,7 @@ func ExampleConvertToCoordinates() {
 		panic("ERROR: X_API_KEY is empty or not found")
 	}
 	svc := w3w.NewService(apiKey)
-	resp, err := svc.V3().ConvertToCoordinatesJson(context.Background(), "filled.count.soap", nil)
+	resp, err := svc.V3().ConvertToCoordinates(context.Background(), "filled.count.soap", nil)
 	if err != nil {
 		panic(err)
 	}
@@ -101,7 +101,7 @@ func ExampleConvertToCoordinatesLanguage() {
 		panic("ERROR: X_API_KEY is empty or not found")
 	}
 	svc := w3w.NewService(apiKey)
-	resp, err := svc.V3().ConvertToCoordinatesJson(context.Background(), "تجتمع.ضباط.ثقافية", &v3.ConvertAPIOpts{
+	resp, err := svc.V3().ConvertToCoordinates(context.Background(), "تجتمع.ضباط.ثقافية", &v3.ConvertAPIOpts{
 		Language: "ar",
 	})
 	if err != nil {
@@ -130,7 +130,7 @@ func ExampleConvertTo3wa() {
 		panic("ERROR: X_API_KEY is empty or not found")
 	}
 	svc := w3w.NewService(apiKey)
-	resp, err := svc.V3().ConvertTo3waJson(context.Background(), v3.Coordinates{
+	resp, err := svc.V3().ConvertTo3wa(context.Background(), v3.Coordinates{
 		Lat: 51.520847,
 		Lng: -0.195521,
 	}, nil)
@@ -146,7 +146,7 @@ func ExampleGridSection() {
 		panic("ERROR: X_API_KEY is empty or not found")
 	}
 	svc := w3w.NewService(apiKey)
-	resp, err := svc.V3().GridSectionJson(context.Background(), v3.BoundingBox{
+	resp, err := svc.V3().GridSection(context.Background(), v3.BoundingBox{
 		SouthWest: v3.Coordinates{
 			Lat: 52.207988,
 			Lng: 0.116126,
@@ -189,7 +189,7 @@ func ExampleExactWhat3WordsAPIErrors() {
 		panic("ERROR: X_API_KEY is empty or not found")
 	}
 	svc := w3w.NewService(apiKey)
-	_, err := svc.V3().ConvertToCoordinatesJson(context.Background(), "filled", nil)
+	_, err := svc.V3().ConvertToCoordinates(context.Background(), "filled", nil)
 	if err != nil {
 		if err, ok := err.(*v3.ErrorResponse); ok {
 			// Refer v3.ErrorCode for more types of errors


### PR DESCRIPTION
Changes:
- Move to returning interfaces for public-facing contracts to make it easier for mocking
- Move from response containers with pointers to each return format to dedicated methods for each format to prevent possible null pointer lookups.
- Add regex based 3 word validation